### PR TITLE
Add functionality to send user back confirmation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}

--- a/puppeteer.js
+++ b/puppeteer.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer');
 
 const abandonedCarForm = async (options) => {
-  const { property, location, description, contact } = options;
+  const { property, location, description, email, address } = options;
   const browser = await puppeteer.launch({headless: false});
   const page = await browser.newPage();
 
@@ -12,12 +12,35 @@ const abandonedCarForm = async (options) => {
   await page.waitFor(2000);
   await page.select('#QuestionSelect', `string:${property}`);
   await page.type('#QuestionText', location, {wait: 100});
+  await page.type('#searchTerm', address, {wait: 100});
+  await page.waitFor(2000);
+  await page.click('#addressInputBtn');
   await page.type('#description', description, {wait: 100});
-  await page.type('#typedInEmailInput', contact, {wait: 100});
+  await page.type('#typedInEmailInput', email, {wait: 100});
+  await page.waitFor(1000);
+  await page.click('#submitReport');
+  await page.waitForNavigation();
+  const confirmationNotes = await page.evaluate(() => {
+    let notes = Array.from(document.querySelectorAll('div.col-sm-9')).map(note => {
+      return note.innerText;
+  });
+    return notes
+  });
+
+  const confirmation = {
+    caseID: confirmationNotes[0],
+    category: confirmationNotes[1],
+    submittedAs: confirmationNotes[2],
+    submittedAt: confirmationNotes[3],
+    notes: confirmationNotes[4]
+  }
+
+  await browser.close();
+  return confirmation
 };
 
 const snowRemoval = async (options) => {
-  const { description, contact } = options
+  const { description, email, address } = options
   const browser = await puppeteer.launch({headless: false});
   const page = await browser.newPage();
 
@@ -26,12 +49,35 @@ const snowRemoval = async (options) => {
 
   await page.select('#categorySelect', 'REQ_SNOWREMOVAL');
   await page.waitFor(2000);
+  await page.type('#searchTerm', address, {wait: 100});
+  await page.waitFor(2000);
+  await page.click('#addressInputBtn');
   await page.type('#description', description, {wait: 100});
-  await page.type('#typedInEmailInput', contact, {wait: 100});
+  await page.type('#typedInEmailInput', email, {wait: 100});
+  await page.waitFor(1000);
+  await page.click('#submitReport');
+  await page.waitForNavigation();
+  const confirmationNotes = await page.evaluate(() => {
+    let notes = Array.from(document.querySelectorAll('div.col-sm-9')).map(note => {
+      return note.innerText;
+  });
+    return notes
+  });
+
+  const confirmation = {
+    caseID: confirmationNotes[0],
+    category: confirmationNotes[1],
+    submittedAs: confirmationNotes[2],
+    submittedAt: confirmationNotes[3],
+    notes: confirmationNotes[4]
+  }
+
+  await browser.close();
+  return confirmation
 }
 
 const illegalParking = async options => {
-  const { location, description, property, contact } = options;
+  const { location, description, property, email, address } = options;
   const browser = await puppeteer.launch({headless: false});
   const page = await browser.newPage();
 
@@ -42,12 +88,34 @@ const illegalParking = async options => {
   await page.waitForSelector('#QuestionSelect');
   await page.type('#QuestionText', location, {wait: 100});
   await page.select('#QuestionSelect', `string:${property}`);
+  await page.type('#searchTerm', address, {wait: 100});
+  await page.waitFor(2000);
+  await page.click('#addressInputBtn');
   await page.type('#description', description, {wait: 100});
-  await page.type('#typedInEmailInput', contact, {wait: 100});
+  await page.type('#typedInEmailInput', email, {wait: 100});
+  await page.waitFor(1000);
+  await page.click('#submitReport');
+  await page.waitForNavigation();
+  const confirmationNotes = await page.evaluate(() => {
+    let notes = Array.from(document.querySelectorAll('div.col-sm-9')).map(note => {
+      return note.innerText;
+  });
+    return notes
+  });
+
+  const confirmation = {
+    caseID: confirmationNotes[0],
+    category: confirmationNotes[1],
+    submittedAs: confirmationNotes[2],
+    submittedAt: confirmationNotes[3],
+    notes: confirmationNotes[4]
+  }
+  await browser.close();
+  return confirmation;
 };
 
 const otherForm = async options => {
-  const { description, contact } = options;
+  const { description, email, address } = options;
   const browser = await puppeteer.launch({headless: false});
   const page = await browser.newPage();
 
@@ -56,6 +124,29 @@ const otherForm = async options => {
 
   await page.select('#categorySelect', 'REQ_OTHER');
   await page.waitForSelector('#description');
+  await page.type('#searchTerm', address, {wait: 100});
+  await page.waitFor(2000);
+  await page.click('#addressInputBtn');
   await page.type('#description', description, {wait: 100});
-  await page.type('#typedInEmailInput', contact, {wait: 100});
+  await page.type('#typedInEmailInput', email, {wait: 100});
+  await page.waitFor(1000);
+  await page.click('#submitReport');
+  await page.waitForNavigation();
+  const confirmationNotes = await page.evaluate(() => {
+    let notes = Array.from(document.querySelectorAll('div.col-sm-9')).map(note => {
+      return note.innerText;
+  });
+    return notes
+  });
+
+  const confirmation = {
+    caseID: confirmationNotes[0],
+    category: confirmationNotes[1],
+    submittedAs: confirmationNotes[2],
+    submittedAt: confirmationNotes[3],
+    notes: confirmationNotes[4]
+  };
+
+  await browser.close();
+  return confirmation
 };


### PR DESCRIPTION
### What does this PR do? 
This PR adds in functionality for each of our Puppeteer functions to submit the form, navigate to the next page, and send back to the FE a confirmation object with the confirmation info as follows: 

```
{
   caseID: 2832723,
   category: 'other',
   submittedAs: 'email@email.com',
   sumbittedAt: '2/22 at 1:00pm',
   notes: 'description text'
}
```

### Where should the reviewer start?
The only changes have happened in 'puppeteer.js' file. Each function has a couple more lines to submit the form and extract the info. 

### Any background info?
I tried to get the picture upload to work, but I cannot get the site to cooperate. That will have to be a feature after MVP, but I don't think it's worth spending time on at the moment. 