### PR TITLE
Increased the decimals on location lat and long from 6 to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 
-node_js:
-  - 12
+node_js: 12
+
+cache: npm
 
 install:
   - "npm install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "stable"
+  - 12
 
 install:
   - "npm install"

--- a/db/migrations/20200223202834_add_more_decimals_on_locations_lat_long.js
+++ b/db/migrations/20200223202834_add_more_decimals_on_locations_lat_long.js
@@ -1,0 +1,18 @@
+
+exports.up = function(knex) {
+  return Promise.all([
+    knex.schema.alterTable('locations', function(table) {
+      table.decimal('lat', 12, 8).alter();
+      table.decimal('long', 12, 8).alter();
+    })
+  ])
+};
+
+exports.down = function(knex) {
+  return Promise.all([
+    knex.schema.alterTable('locations', function(table) {
+      table.decimal('lat', 10, 6).alter();
+      table.decimal('long', 10, 6).alter();
+    })
+  ])
+};

--- a/test/locations.test.js
+++ b/test/locations.test.js
@@ -46,8 +46,8 @@ describe('GET /api/v1/locations', () => {
         expect(res.statusCode).to.equal(200);
         const locations = JSON.parse(res.payload)
         expect(locations[0].address_desc).to.equal("1701 Market St")
-        expect(locations[0].lat).to.equal("39.751129")
-        expect(locations[0].long).to.equal("-104.997486")
+        expect(locations[0].lat).to.equal("39.75112900")
+        expect(locations[0].long).to.equal("-104.99748600")
         expect(locations.length).to.equal(2)
     });
 });


### PR DESCRIPTION
**What's going on**
Because precision of addresses increases with the number of decimals in the `lat` and `long` I added more decimal places to our database's `locations` table columns `lat` and `long`.

**.travis.yml**
In order to speed up the build process I specified both a `node_js` version `12` and instructions to cache node with `cache: npm` per Travis-CI documentation.

**Where to start**
In the knex migration file `db/migrations/20200223202834_add_more_decimals_on_locations_lat_long.js` I've altered the table columns on `locations` to increase the number of digits total (12) and the number of digits after the decimal (8) using `table.decimal('lat', 12, 8).alter();`

**Run migration locally**
When this is pulled down, alter your database with the following terminal commands:
```
knex migrate:latest; knex migrate:latest --env test
```

*I also locally verified the rollback works too with `knex migrate:rollback`*

**Testing**
I updated a test file to reflect more zeros after the 6-decimal lat/long. I also manually checked the api call in Postman to make sure the address description would not change with trailing zeroes.

** Closes #20 **
