### PR TITLE
Add test endpoint for FE to use

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,7 +1,8 @@
 const locations = require('./api/v1/locations');
 const reports = require('./api/v1/reports');
 const Joi = require('@hapi/joi');
-const schema = require('./schema')
+const schema = require('./schema');
+const puppeteer = require('puppeteer');
 
 
 module.exports = [
@@ -52,5 +53,56 @@ module.exports = [
             })
         }
     }
+  },
+  {
+    method: 'POST',
+    path: '/api/v1/test/reports',
+    handler: async function(request, reply) {
+      const { report, location } = request.payload;
+      const browser = await puppeteer.launch();
+      const page = await browser.newPage();
+  
+      await page.goto('https://www.denvergov.org/pocketgov/#/report-a-problem', {waitUntil: 'networkidle2'});
+      await page.waitFor(10000);
+      await browser.close();
+
+      for (let requiredParameter of ['category', 'description', 'image', 'email']) {
+        if (!report.hasOwnProperty(requiredParameter)) {
+          return reply.response({ error: `The expected format is: {report: { category: <String>, description: <String>, image: <String>, email: <String> }}. You're missing the ${requiredParameter} property.`}).code(422)
+        }
+      };
+
+      for (let requiredParameter of ['lat', 'long']) {
+        if (!location.hasOwnProperty(requiredParameter)) {
+          return reply.response({ error: `The expected format is: {location: { lat: <String>, long: <String> }}. You're missing the ${requiredParameter} property.`}).code(422)
+        }
+      };
+      const replyReport = {
+        report: {
+          category: report.category,
+          description: report.description,
+          image: report.image,
+          email: report.email,
+          location_id: 34,
+          id: 2
+        },
+        confirmation311: {
+          caseID: '13344',
+          category: report.category,
+          submittedAs: report.email,
+          submittedAt: '2/22 at 1:20pm',
+          notes: report.description
+        }
+      };
+      
+      return reply.response(replyReport).code(201)
+    },
+    options: {
+      validate: {
+          query: Joi.object({
+              serviceKey: Joi.string().required().valid(process.env.SERVICE_KEY)
+          })
+      }
+  }
   }
 ];


### PR DESCRIPTION
### What does this PR do?
This PR creates a testing endpoint for the Front End to use without creating so many reports for Denver.

### Where should the reviewer start?
In `lib/routes.js`, theres a new endpoint `/api/v1/test/reports` which simulates the actual reports endpoint.

### Background Info
I used Puppeteer to try to simulate the process as much as possible. I add a 10 second setTimeout to make it stall to help the front end with timing

### Issues
Closes #37 