### PR TITLE
Check for existing location before assigning a new one

### DIFF
--- a/lib/api/v1/reports.js
+++ b/lib/api/v1/reports.js
@@ -46,13 +46,14 @@ exports.methods = {
     };
 
     try {
+      const existingLocationID = await knex('locations').where('lat', `${location.lat}`).andWhere('long', `${location.long}`);
       const locationID = await knex('locations').insert(fullLocation, ['id']);
       const fullReport = {
         category: report.category,
         description: report.description,
         image: report.image,
         email: report.email,
-        location_id: locationID[0].id
+        location_id: existingLocationID.length ? existingLocationID[0].id : locationID[0].id
       };
       const newReport = await knex('reports').insert(fullReport, 'id');
       const puppeteerOptions = {

--- a/lib/api/v1/reports.js
+++ b/lib/api/v1/reports.js
@@ -24,7 +24,6 @@ exports.methods = {
   create: async function(request, reply) {
     let confirmation;
     const { report, location } = request.payload;
-    console.log("payload within create", report, location)
     for (let requiredParameter of ['category', 'description', 'image', 'email']) {
       if (!report.hasOwnProperty(requiredParameter)) {
         return reply.response({ error: `The expected format is: {report: { category: <String>, description: <String>, image: <String>, email: <String> }}. You're missing the ${requiredParameter} property.`}).code(422)
@@ -36,12 +35,10 @@ exports.methods = {
         return reply.response({ error: `The expected format is: {location: { lat: <String>, long: <String> }}. You're missing the ${requiredParameter} property.`}).code(422)
       }
     };
-    console.log("location within create", location)
 
     const googleInfo = new Geocode(location);
-    console.log("googleInfo in post", googleInfo)
+
     const address = await googleInfo.fetchAddress();
-    console.log("address from Google", address )
     const fullLocation = {
       lat: location.lat,
       long: location.long,
@@ -50,14 +47,26 @@ exports.methods = {
 
     try {
       const existingLocationID = await knex('locations').where('lat', `${location.lat}`).andWhere('long', `${location.long}`);
-      const locationID = await knex('locations').insert(fullLocation, ['id']);
-      const fullReport = {
-        category: report.category,
-        description: report.description,
-        image: report.image,
-        email: report.email,
-        location_id: existingLocationID.length ? existingLocationID[0].id : locationID[0].id
-      };
+      let fullReport = {}
+      if (existingLocationID.length > 0) {
+        fullReport = {
+          category: report.category,
+          description: report.description,
+          image: report.image,
+          email: report.email,
+          location_id: existingLocationID[0].id
+        };
+      } else {
+        const locationID = await knex('locations').insert(fullLocation, ['id']);
+        fullReport = {
+          category: report.category,
+          description: report.description,
+          image: report.image,
+          email: report.email,
+          location_id: locationID[0].id
+        };
+      }
+
       const newReport = await knex('reports').insert(fullReport, 'id');
       const puppeteerOptions = {
         description: report.description,

--- a/lib/api/v1/reports.js
+++ b/lib/api/v1/reports.js
@@ -24,7 +24,7 @@ exports.methods = {
   create: async function(request, reply) {
     let confirmation;
     const { report, location } = request.payload;
-
+    console.log("payload within create", report, location)
     for (let requiredParameter of ['category', 'description', 'image', 'email']) {
       if (!report.hasOwnProperty(requiredParameter)) {
         return reply.response({ error: `The expected format is: {report: { category: <String>, description: <String>, image: <String>, email: <String> }}. You're missing the ${requiredParameter} property.`}).code(422)
@@ -36,9 +36,12 @@ exports.methods = {
         return reply.response({ error: `The expected format is: {location: { lat: <String>, long: <String> }}. You're missing the ${requiredParameter} property.`}).code(422)
       }
     };
+    console.log("location within create", location)
 
     const googleInfo = new Geocode(location);
+    console.log("googleInfo in post", googleInfo)
     const address = await googleInfo.fetchAddress();
+    console.log("address from Google", address )
     const fullLocation = {
       lat: location.lat,
       long: location.long,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,6 +3,9 @@ const reports = require('./api/v1/reports');
 const Joi = require('@hapi/joi');
 const schema = require('./schema');
 const puppeteer = require('puppeteer');
+const env = process.env.NODE_ENV || 'development';
+const configuration = require('../knexfile')[env];
+const knex = require('knex')(configuration);
 
 
 module.exports = [
@@ -61,6 +64,7 @@ module.exports = [
       const { report, location } = request.payload;
       const browser = await puppeteer.launch();
       const page = await browser.newPage();
+      const existingLocationID = await knex('locations').where('lat', `${location.lat}`).andWhere('long', `${location.long}`);
   
       await page.goto('https://www.denvergov.org/pocketgov/#/report-a-problem', {waitUntil: 'networkidle2'});
       await page.waitFor(10000);
@@ -83,7 +87,7 @@ module.exports = [
           description: report.description,
           image: report.image,
           email: report.email,
-          location_id: 34,
+          location_id: existingLocationID.length ? existingLocationID[0].id : 34,
           id: 2
         },
         confirmation311: {

--- a/lib/services/geocode.js
+++ b/lib/services/geocode.js
@@ -10,10 +10,15 @@ class Geocode {
   async fetchAddress() {
     // format: latlng=40.714224,-73.961452
     const latLongString = `${this.latLong.lat},${this.latLong.long}`
-    let url = `https://maps.googleapis.com/maps/api/geocode/json?latlng=${latLongString}&key=${process.env.GOOGLE_GEOCODE_KEY}`;
-    let res = await fetch(url);
-    let googleInfo = await res.json();
-    return googleInfo
+    const url = `https://maps.googleapis.com/maps/api/geocode/json?latlng=${latLongString}&key=${process.env.GOOGLE_GEOCODE_KEY}`
+
+    try {
+      const response = await fetch(url);
+      const json = await response.json();
+      return json
+    } catch (error) {
+      return error
+    }
   }
 
 }


### PR DESCRIPTION
### What does this PR do?
This PR adds in functionality in the POST `/api/v1/reports` endpoint to check that the location submitted doesn't already exist in the database. If it does, that `location_id` is used as the location for the new report. This avoids creating multiple IDs for the same location.

### Where should the reviewer start?
In `routes.js` and `reports.js` I've added this functionality to the POST endpoint and to the new TEST endpoint.

### Issues
Closes #31 